### PR TITLE
Add simple tests to verify that Outlaw traits improve DPS

### DIFF
--- a/shadowcraft/calcs/rogue/Aldriana/__init__.py
+++ b/shadowcraft/calcs/rogue/Aldriana/__init__.py
@@ -1181,7 +1181,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
         self.main_gauche_proc_rate = self.outlaw_mastery_conversion * self.stats.get_mastery_from_rating(current_stats['mastery'])
         cost_reducer = self.main_gauche_proc_rate * self.combat_potency_from_mg
 
-        #compute MG lumped ability costs
+        # Compute Main Gauche lumped ability costs
         self.run_through_energy_cost = self.get_spell_cost('run_through') - (4 * self.traits.fatebringer) - cost_reducer
         self.between_the_eyes_energy_cost = self.get_spell_cost('between_the_eyes') - (4 * self.traits.fatebringer) - cost_reducer
         self.pistol_shot_energy_cost = self.get_spell_cost('run_through') - (4 * self.traits.fatebringer) - cost_reducer
@@ -1195,7 +1195,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             self.ghostly_strike_cost = self.get_spell_cost('ghostly_strike') - cost_reducer
 
         self.white_swing_downtime = self.settings.response_time / self.get_spell_cd('vanish')
-        #compute dps phases each non-rerolling rtb buff combo ar and not
+        # Compute dps phases each non-rerolling RtB buff combo AR and not
         phases = {}
         ar_phases = {}
 
@@ -1236,17 +1236,17 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             keep_gm_uptime = keep_gm_chance/keep_chance
             keep_tb_uptime = keep_tb_chance/keep_chance
             keep_shark_uptime = keep_shark_chance/keep_chance
-            #merge ar and non-ar into single phases
+            # Merge AR and non-AR into single phases
             aps_keep = self.merge_attacks_per_second(phases, total_time=keep_chance)
             aps_keep_ar = self.merge_attacks_per_second(ar_phases, total_time=keep_chance)
-            #technically there is a convergence relationship here but ignoring it
+            # Technically there is a convergence relationship here but ignoring it
             if self.talents.alacrity:
                 alacrity_stacks = self.get_average_alacrity(aps_keep)
                 alacrity_stacks_ar = self.get_average_alacrity(aps_keep_ar)
             else:
                 alacrity_stacks = 0
                 alacrity_stacks_ar = 0
-            #now compute the average time for each reroll
+            # Now compute the average time for each reroll
             phases = {}
             ar_phases = {}
             net_reroll_time = 0.0
@@ -1278,7 +1278,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
                 if melee:
                     reroll_gm_time += chance * reroll_time
 
-            #check for reroll time, to protect from divide by zero
+            # Check for reroll time, to protect from divide by zero
             if net_reroll_time:
                 reroll_tb_uptime = reroll_tb_time/net_reroll_time
                 reroll_shark_uptime = reroll_shark_time/net_reroll_time
@@ -1290,9 +1290,9 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
 
             aps_reroll = self.merge_attacks_per_second(phases, total_time=net_reroll_time)
             aps_reroll_ar = self.merge_attacks_per_second(phases, total_time=net_reroll_time_ar)
-            #now combine the reroll and keep dicts
+            # Now combine the reroll and keep dicts
             rtb_keep_duration = 6 * (1+ self.settings.finisher_threshold)
-            #will pandemic into rtb based on keep_chance
+            # Will pandemic into RtB based on keep_chance
             rtb_keep_duration *= 1 + (0.3 * keep_chance)
             reroll_duration = net_reroll_time * len(self.settings.cycle.reroll_list)
 
@@ -1310,16 +1310,13 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             gm_uptime = (keep_uptime * keep_gm_uptime) + (1 - keep_uptime) * reroll_gm_uptime
             shark_uptime = (keep_uptime * keep_shark_uptime) + (1 - keep_uptime) * reroll_shark_uptime
 
-        #determine ar uptime and merge the two distributions
+        # Determine AR uptime and merge the two distributions
         attacks_per_second = self.merge_attacks_per_second({'normal': (self.ar_cd - self.ar_duration, aps_normal),
             'ar': (self.ar_duration, aps_ar)}, total_time=self.ar_cd)
         ar_uptime = self.ar_duration / self.ar_cd
         tb_seconds_per_second = 0
 
-        # print aps_normal
-        # print aps_ar
-        # print attacks_per_second
-        #if rtb loop on ar cooldown
+        # If RtB loop on AR cooldown
         if not self.talents.slice_and_dice:
             old_ar_cd = self.ar_cd
             loop_counter = 0
@@ -1331,15 +1328,8 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
                             cp_spend_per_second += attacks_per_second[ability][cp] * cp
                 tb_seconds_per_second = 2 * cp_spend_per_second * tb_uptime
                 new_ar_cd = self.ar_cd/(1 + tb_seconds_per_second)
-                # print attacks_per_second
-                # print cp_spend_per_second, tb_seconds_per_second
-                #remerge the aps
-                #print new_ar_cd
-                #print attacks_per_second
                 attacks_per_second = self.merge_attacks_per_second({'normal': (new_ar_cd - self.ar_duration, aps_normal),
                     'ar': (self.ar_duration, aps_ar)}, total_time=new_ar_cd)
-                # print new_ar_cd
-                # print "-------"
                 if old_ar_cd - new_ar_cd < 0.1:
                     break
                 else:
@@ -1347,9 +1337,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
 
             ar_uptime = self.ar_duration / new_ar_cd
 
-        # print self.ar_duration, new_ar_cd
-        # print ar_uptime
-        #add in cannonball and killing spree
+        # Add in Cannonball and Killing Spree
         if self.talents.killing_spree:
             ksp_cd = self.get_spell_cd('killing_spree') / (1. + tb_seconds_per_second)
             #ksp is 7 hits per hand
@@ -1359,7 +1347,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             attacks_per_second['cannonball_barrage'] = 1./cannonball_barrage_cd
 
 
-        #figure swing timer and add mg
+        # Figure swing timer and add Main Gauche
         attack_speed_multiplier = self.get_attack_speed_multiplier(current_stats, snd=self.talents.slice_and_dice)
         attack_speed_multiplier *= (1 + (0.2 * ar_uptime))
         if not self.talents.slice_and_dice:
@@ -1368,7 +1356,8 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
         attacks_per_second['mh_autoattacks'] = 1./swing_timer
         attacks_per_second['oh_autoattacks'] = 1./swing_timer
         attacks_per_second['main_gauche'] = self.main_gauche_proc_rate * attacks_per_second['mh_autoattacks'] * self.dual_wield_mh_hit_chance()
-        #add in mg
+
+        # Add in Main Gauche
         for ability in attacks_per_second:
             if ability in ['ambush', 'ghostly_strike', 'killing_spree', 'saber_slash']:
                 attacks_per_second['main_gauche'] += self.main_gauche_proc_rate * attacks_per_second[ability]
@@ -1390,10 +1379,9 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             attacks_per_second['blunderbuss'] = 0.33 * attacks_per_second['pistol_shot']
             attacks_per_second['pistol_shot'] -= attacks_per_second['blunderbuss']
 
-        # print attacks_per_second
         return attacks_per_second, crit_rates, additional_info
 
-    # probably don't actually need shark or tb here but simpler
+    # Probably don't actually need Shark or True Bearing here but simpler
     def outlaw_attack_counts_mincycle(self, current_stats, snd=False, ar=False, jolly=False, melee=False,
                                       buried=False, broadsides=False, duration=30, shark=False, true_bearing=True):
 

--- a/shadowcraft/objects/artifact.py
+++ b/shadowcraft/objects/artifact.py
@@ -33,7 +33,7 @@ class Artifact(object):
 
     def initialize_traits(self, trait_string):
         if len(trait_string) != len(self.allowed_traits):
-            raise InvalidTraitException(_('Trait strings must be {traits} characters long').format(traits=len(allowed_traits)))
+            raise InvalidTraitException(_('Trait strings must be {traits} characters long').format(traits=len(self.allowed_traits)))
         self.traits = {}
         for trait in xrange(len(self.allowed_traits)):
             self.set_trait(self.allowed_traits[trait], int(trait_string[trait]))

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -156,11 +156,18 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
         a, b = self.compare({'traits': '000000000000000000'}, {'traits': '001000000000000000'}, 'get_dps')
         self.assertGreater(b, a)
 
-    def test_blade_dancer_single_target_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 0}, 'get_dps')
-        self.assertEqual(b, a)
+    def test_blade_flurry_hurts_single_target_dps(self):
+        cycle = _settings.OutlawCycle(blade_flurry=True)
+        a, b = self.compare({}, {'num_boss_adds': 0}, 'get_dps')
+        self.assertLess(b, a)
+
+    def test_blade_dancer_improves_blade_flurry_penalty(self):
+        cycle = _settings.OutlawCycle(blade_flurry=True)
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000'}, 'get_dps')
+        self.assertLess(a, b)
 
     def test_blade_dancer_multi_target_dps(self):
+        cycle = _settings.OutlawCycle(blade_flurry=True)
         a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3}, 'get_dps')
         self.assertGreater(b, a)
 
@@ -189,7 +196,8 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
         self.assertEqual(b, a)
 
     def test_black_powder_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000010000000'}, 'get_dps')
+        cycle = _settings.OutlawCycle(between_the_eyes_policy='shark')
+        a, b = self.compare({'traits': '000000000000000000', 'cycle': cycle}, {'traits': '000000000010000000', 'cycle': cycle}, 'get_dps')
         self.assertGreater(b, a)
 
     def test_greed_dps(self):

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -285,6 +285,42 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
         self.assertGreater(rank1, base)
 
 
+    # These are sanity checks; they are what is expected from current modeling, so they're included to help
+    # guard against regressions in the calculator.
+    def test_best_rank_1(self):
+        gstrike = self.factory.build(talent_str='0000000').get_dps()
+        swords = self.factory.build(talent_str='1000000').get_dps()
+        quick = self.factory.build(talent_str='2000000').get_dps()
+        self.assertGreater(gstrike, swords, 'Swordmaster %s > Ghostly Strike %s' % (swords, gstrike))
+        self.assertGreater(gstrike, quick, 'Quick Draw %s > Ghostly Strike %s' % (quick, gstrike))
+
+
+    def test_best_rank_3(self):
+        stratagem = self.factory.build(talent_str='0000000').get_dps()
+        anticipation = self.factory.build(talent_str='0010000').get_dps()
+        vigor = self.factory.build(talent_str='0020000').get_dps()
+        self.assertGreater(stratagem, anticipation, 'Anticipation %s > Stratagem %s' % (anticipation, stratagem))
+        self.assertGreater(stratagem, vigor, 'Vigor %s > Stratagem %s' % (vigor, stratagem))
+
+
+    def test_best_rank_6(self):
+        cannons = self.factory.build(talent_str='0000000').get_dps()
+        alacrity = self.factory.build(talent_str='0000010').get_dps()
+        kspree = self.factory.build(talent_str='0000020').get_dps()
+        self.assertGreater(alacrity, kspree, 'KSpree %s > Alacrity %s' % (kspree, alacrity))
+        self.assertGreater(alacrity, cannons, 'Cannons %s > Alacrity %s' % (cannons, alacrity))
+
+
+    def test_best_rank_7(self):
+        snd = self.factory.build(talent_str='0000000').get_dps()
+        mfd = self.factory.build(talent_str='0000001').get_dps()
+        dfa = self.factory.build(talent_str='0000002').get_dps()
+        self.assertGreater(mfd, snd, 'SnD %s > Marked for Death %s' % (snd, mfd))
+        self.assertGreater(mfd, dfa, 'Death From Above %s > mfd %s' % (dfa, mfd))
+
+
+
+
 class TestAssassinationRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
         self.calculator = RogueDamageCalculatorFactory('assassination').build()

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -86,7 +86,7 @@ class RogueDamageCalculatorFactory:
 
         # Set up settings.
         test_settings = _settings.Settings(self.cycle, response_time=self.response_time, duration=self.duration,
-                                         adv_params=self.adv_params, is_demon=self.is_demon, num_boss_adds=self.num_boss_adds)
+                                         adv_params=self.adv_params, is_demon=self.is_demon, num_boss_adds=self.num_boss_adds, finisher_threshold=self.finisher_threshold)
 
         self.calculator = AldrianasRogueDamageCalculator(test_stats, test_talents, test_traits, self.buffs, test_race, self.spec, test_settings, self.level)
         self.calculator.level = 110

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -192,13 +192,13 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
 
     def test_blade_flurry_hurts_single_target_dps(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        base, rank1 = self.compare_dps({}, {'num_boss_adds': 0})
+        base, rank1 = self.compare_dps({}, {'num_boss_adds': 0, 'cycle': cycle})
         self.assertLess(rank1, base)
 
 
     def test_blade_dancer_improves_blade_flurry_penalty(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000'})
+        base, rank1 = self.compare_dps({'traits': '000000000000000000', 'cycle': cycle}, {'traits': '000100000000000000', 'cycle': cycle})
         self.assertGreater(rank1, base)
         rank2 = self.factory.build(traits='000200000000000000').get_dps()
         rank3 = self.factory.build(traits='000300000000000000').get_dps()
@@ -208,10 +208,11 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
 
     def test_blade_dancer_multi_target_dps(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3})
+        base = self.factory.build(traits='000000000000000000', cycle=cycle).get_dps()
+        rank1 = self.factory.build(traits='000100000000000000', cycle=cycle, num_boss_adds=3).get_dps()
+        rank2 = self.factory.build(traits='000200000000000000', cycle=cycle, num_boss_adds=3).get_dps()
+        rank3 = self.factory.build(traits='000300000000000000', cycle=cycle, num_boss_adds=3).get_dps()
         self.assertGreater(rank1, base)
-        rank2 = self.factory.build(traits='000200000000000000', num_boss_adds=3).get_dps()
-        rank3 = self.factory.build(traits='000300000000000000', num_boss_adds=3).get_dps()
         self.assertGreater(rank2, rank1)
         self.assertGreater(rank3, rank2)
 

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -7,32 +7,38 @@ from shadowcraft.objects import stats as _stats
 from shadowcraft.objects import procs as _procs
 from shadowcraft.objects import talents as _talents
 from shadowcraft.objects import artifact as _artifact
+from shadowcraft.objects import artifact_data as artifact_data
 from shadowcraft.calcs.rogue.Aldriana import settings as _settings
 
-class RogueDamageCalculatorTestBase(object):
-    def setUp(self):
-        self.talent_str = '1000000'
+class RogueDamageCalculatorFactory:
+    def __init__(self, spec, **kwargs):
+        self.class_name = 'rogue'
+        self.talent_str = '0000000'
         self.buffs = _buffs.Buffs('short_term_haste_buff', 'flask_wod_agi', 'food_wod_versatility')
         self.procs = _procs.ProcsList()
         self.gear_buffs = _stats.GearBuffs('gear_specialization')
         self.traits = '000000000000000000'
         self.level = 110
         self.race = 'pandaren'
-        self.agi = 20909
-        self.stam = 19566
-        self.crit = 4402
-        self.haste = 5150
-        self.mastery = 5999
-        self.versatility = 1515
+        self.agi = 21122
+        self.stam = 28367
+        self.crit = 6306
+        self.haste = 3260
+        self.mastery = 3706
+        self.versatility = 3486
         self.response_time = 0.5
         self.duration = 360
         self.is_demon = False
         self.num_boss_adds = 0
         self.adv_params = 0
+        self.finisher_threshold = 5
+        self.buildSpecDefaults(spec)
+        self.__dict__.update(kwargs)
 
     def buildSpecDefaults(self, spec, weapon_dps=2100):
         self.spec = spec
         if spec == "outlaw":
+            self.talent_str = '1010022'
             self.mh = _stats.Weapon(weapon_dps * 2.6, 2.6, 'sword', None)
             self.oh = _stats.Weapon(weapon_dps * 2.6, 2.6, 'sword', None)
             self.cycle = _settings.OutlawCycle(blade_flurry=False,
@@ -41,12 +47,15 @@ class RogueDamageCalculatorTestBase(object):
                                               shark_reroll=1,
                                               true_bearing_reroll=1,
                                               buried_treasure_reroll=1,
-                                              broadsides_reroll=1)
+                                              broadsides_reroll=1,
+                                              between_the_eyes_policy='never')
         elif spec == "assassination":
+            self.talent_str = '2101220'
             self.mh = _stats.Weapon(weapon_dps * 1.8, 1.8, 'dagger', None)
             self.oh = _stats.Weapon(weapon_dps * 1.8, 1.8, 'dagger', None)
             self.cycle = _settings.AssassinationCycle()
         elif spec == "subtlety":
+            self.talent_str = '2100120'
             self.mh = _stats.Weapon(weapon_dps * 1.8, 1.8, 'dagger', None)
             self.oh = _stats.Weapon(weapon_dps * 1.8, 1.8, 'dagger', None)
             self.cycle = _settings.SubtletyCycle(cp_builder='backstab',  dance_finishers_allowed=True, positional_uptime=0.9)
@@ -54,9 +63,10 @@ class RogueDamageCalculatorTestBase(object):
             raise "Invalid spec: %s" % spec
 
 
-    def buildCalculator(self):
+    def build(self, **kwargs):
+        self.__dict__.update(kwargs)
+
         test_race = _race.Race(self.race)
-        test_class = 'rogue'
 
         # Set up a calcs object..
         test_stats = _stats.Stats(self.mh, self.oh, self.procs,
@@ -69,10 +79,10 @@ class RogueDamageCalculatorTestBase(object):
                                     versatility=self.versatility)
 
         # Initialize talents..
-        test_talents = _talents.Talents(self.talent_str, self.spec, test_class, level=self.level)
+        test_talents = _talents.Talents(self.talent_str, self.spec, self.class_name, level=self.level)
 
         #initialize artifact traits..
-        test_traits = _artifact.Artifact(self.spec, test_class, self.traits)
+        test_traits = _artifact.Artifact(self.spec, self.class_name, self.traits)
 
         # Set up settings.
         test_settings = _settings.Settings(self.cycle, response_time=self.response_time, duration=self.duration,
@@ -80,6 +90,16 @@ class RogueDamageCalculatorTestBase(object):
 
         self.calculator = AldrianasRogueDamageCalculator(test_stats, test_talents, test_traits, self.buffs, test_race, self.spec, test_settings, self.level)
         self.calculator.level = 110
+        return self.calculator
+
+class RogueDamageCalculatorTestBase:
+    def compare(self, a, b, method=None):
+        calc_a = self.factory.build(**a)
+        calc_b = self.factory.build(**b)
+        if method is not None:
+            return (getattr(calc_a, method)(), getattr(calc_b, method)())
+        else:
+            return (a, b)
 
     def test_oh_penalty(self):
         self.assertAlmostEqual(self.calculator.oh_penalty(), 0.5)
@@ -89,18 +109,15 @@ class RogueDamageCalculatorTestBase(object):
 
     def test_dps_breakdowns(self):
         # TODO: Add assertions. This at least runs it though.
-        print "DPS Breakdown"
-        print(self.calculator.get_dps_breakdown())
+        self.calculator.get_dps_breakdown()
 
     def test_get_talents_ranking(self):
         # TODO: Add assertions. This at least runs it though.
-        print "Talent ranking"
-        print(self.calculator.get_talents_ranking())
+        self.calculator.get_talents_ranking()
 
     def test_get_trait_ranking(self):
         # TODO: Add assertions. This at least runs it though.
-        print "Trait ranking"
-        print(self.calculator.get_trait_ranking())
+        self.calculator.get_trait_ranking()
 
     def test_ep(self):
         ep_values = self.calculator.get_ep()
@@ -123,48 +140,112 @@ class RogueDamageCalculatorTestBase(object):
 
 class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
-        super(TestOutlawRogueDamageCalculator, self).setUp()
-        self.buildSpecDefaults('outlaw')
-        self.num_boss_adds = 0
-        self.buildCalculator()
+        self.factory = RogueDamageCalculatorFactory('outlaw')
+        self.calculator = self.factory.build()
 
+    # This is a dumb test but illustrates how we can test changes in a calculator
+    def test_mastery_helps_dps(self):
+        a, b = self.compare({"mastery": 3706}, {"mastery": 4706}, "get_dps_breakdown")
+        self.assertGreater(b["main_gauche"], a["main_gauche"])
+
+    def test_cursed_edges_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '010000000000000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_fates_thirst_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '001000000000000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_blade_dancer_single_target_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 0}, 'get_dps')
+        self.assertEqual(b, a)
+
+    def test_blade_dancer_multi_target_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_fatebringer_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000010000000000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_gunslinger_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000001000000000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_hidden_blade_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000100000000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_fortune_strikes_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000010000000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_ghostly_shell_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000001000000000'}, 'get_dps')
+        self.assertEqual(b, a)
+
+    def test_deception_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000100000000'}, 'get_dps')
+        self.assertEqual(b, a)
+
+    def test_black_powder_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000010000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_greed_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000001000000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_blurred_time_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000100000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_fortunes_boon_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000010000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_fortunes_strike_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000001000'}, 'get_dps')
+        self.assertGreater(b, a)
+
+        a, b2 = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000002000'}, 'get_dps')
+        self.assertGreater(b2, b)
+
+        a, b3 = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000003000'}, 'get_dps')
+        self.assertGreater(b3, b2)
+
+    def test_blademaster_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000000100'}, 'get_dps')
+        self.assertEqual(b, a)
+
+    def test_blunderbuss_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000000010'}, 'get_dps')
+        self.assertGreater(b, a)
+
+    def test_cursed_steel_dps(self):
+        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000000001'}, 'get_dps')
+        self.assertGreater(b, a)
 
 class TestAssassinationRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
-        super(TestAssassinationRogueDamageCalculator, self).setUp()
-        self.buildSpecDefaults('assassination')
-        self.num_boss_adds = 0
-        self.buildCalculator()
-
+        self.calculator = RogueDamageCalculatorFactory('assassination').build()
 
 class TestSubtletyRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
-        super(TestSubtletyRogueDamageCalculator, self).setUp()
-        self.buildSpecDefaults('subtlety')
-        self.num_boss_adds = 0
-        self.buildCalculator()
+        self.calculator = RogueDamageCalculatorFactory('subtlety').build()
 
 ## Multi-target
 
 class TestAOEOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
-        super(TestAOEOutlawRogueDamageCalculator, self).setUp()
-        self.buildSpecDefaults('outlaw')
-        self.num_boss_adds = 3
-        self.buildCalculator()
+        self.calculator = RogueDamageCalculatorFactory('outlaw').build(num_boss_adds=3)
 
 
 class TestAOEAssassinationRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
-        super(TestAOEAssassinationRogueDamageCalculator, self).setUp()
-        self.buildSpecDefaults('assassination')
-        self.num_boss_adds = 3
-        self.buildCalculator()
+        self.calculator = RogueDamageCalculatorFactory('assassination').build(num_boss_adds=3)
 
 
 class TestAOESubtletyRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):
-        super(TestAOESubtletyRogueDamageCalculator, self).setUp()
-        self.buildSpecDefaults('subtlety')
-        self.num_boss_adds = 3
-        self.buildCalculator()
+        self.calculator = RogueDamageCalculatorFactory('subtlety').build(num_boss_adds=3)

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -93,13 +93,16 @@ class RogueDamageCalculatorFactory:
         return self.calculator
 
 class RogueDamageCalculatorTestBase:
+    def compare_dps(self, a, b):
+        return self.compare(a, b, "get_dps")
+
     def compare(self, a, b, method=None):
         calc_a = self.factory.build(**a)
         calc_b = self.factory.build(**b)
         if method is not None:
             return (getattr(calc_a, method)(), getattr(calc_b, method)())
         else:
-            return (a, b)
+            return (calc_a, calc_b)
 
     def test_oh_penalty(self):
         self.assertAlmostEqual(self.calculator.oh_penalty(), 0.5)
@@ -145,93 +148,93 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
 
     # This is a dumb test but illustrates how we can test changes in a calculator
     def test_mastery_helps_dps(self):
-        a, b = self.compare({"mastery": 3706}, {"mastery": 4706}, "get_dps_breakdown")
+        a, b = self.compare({"mastery": 3706}, {"mastery": 4706}, 'get_dps_breakdown')
         self.assertGreater(b["main_gauche"], a["main_gauche"])
 
     def test_cursed_edges_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '010000000000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '010000000000000000'})
         self.assertGreater(b, a)
 
     def test_fates_thirst_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '001000000000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '001000000000000000'})
         self.assertGreater(b, a)
 
     def test_blade_flurry_hurts_single_target_dps(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        a, b = self.compare({}, {'num_boss_adds': 0}, 'get_dps')
+        a, b = self.compare_dps({}, {'num_boss_adds': 0})
         self.assertLess(b, a)
 
     def test_blade_dancer_improves_blade_flurry_penalty(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000'})
         self.assertLess(a, b)
 
     def test_blade_dancer_multi_target_dps(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3})
         self.assertGreater(b, a)
 
     def test_fatebringer_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000010000000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000010000000000000'})
         self.assertGreater(b, a)
 
     def test_gunslinger_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000001000000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000001000000000000'})
         self.assertGreater(b, a)
 
     def test_hidden_blade_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000100000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000100000000000'})
         self.assertGreater(b, a)
 
     def test_fortune_strikes_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000010000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000010000000000'})
         self.assertGreater(b, a)
 
     def test_ghostly_shell_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000001000000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000001000000000'})
         self.assertEqual(b, a)
 
     def test_deception_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000100000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000100000000'})
         self.assertEqual(b, a)
 
     def test_black_powder_dps(self):
         cycle = _settings.OutlawCycle(between_the_eyes_policy='shark')
-        a, b = self.compare({'traits': '000000000000000000', 'cycle': cycle}, {'traits': '000000000010000000', 'cycle': cycle}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000', 'cycle': cycle}, {'traits': '000000000010000000', 'cycle': cycle})
         self.assertGreater(b, a)
 
     def test_greed_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000001000000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000001000000'})
         self.assertGreater(b, a)
 
     def test_blurred_time_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000100000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000100000'})
         self.assertGreater(b, a)
 
     def test_fortunes_boon_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000010000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000010000'})
         self.assertGreater(b, a)
 
     def test_fortunes_strike_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000001000'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000001000'})
         self.assertGreater(b, a)
 
-        a, b2 = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000002000'}, 'get_dps')
+        a, b2 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000002000'})
         self.assertGreater(b2, b)
 
-        a, b3 = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000003000'}, 'get_dps')
+        a, b3 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000003000'})
         self.assertGreater(b3, b2)
 
     def test_blademaster_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000000100'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000100'})
         self.assertEqual(b, a)
 
     def test_blunderbuss_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000000010'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000010'})
         self.assertGreater(b, a)
 
     def test_cursed_steel_dps(self):
-        a, b = self.compare({'traits': '000000000000000000'}, {'traits': '000000000000000001'}, 'get_dps')
+        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000001'})
         self.assertGreater(b, a)
 
 class TestAssassinationRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -146,96 +146,144 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
         self.factory = RogueDamageCalculatorFactory('outlaw')
         self.calculator = self.factory.build()
 
+
     # This is a dumb test but illustrates how we can test changes in a calculator
     def test_mastery_helps_dps(self):
         a, b = self.compare({"mastery": 3706}, {"mastery": 4706}, 'get_dps_breakdown')
         self.assertGreater(b["main_gauche"], a["main_gauche"])
 
+
     def test_cursed_edges_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '010000000000000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '010000000000000000'})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='020000000000000000', num_boss_adds=3).get_dps()
+        rank3 = self.factory.build(traits='030000000000000000', num_boss_adds=3).get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_fates_thirst_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '001000000000000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '001000000000000000'})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='002000000000000000', num_boss_adds=3).get_dps()
+        rank3 = self.factory.build(traits='003000000000000000', num_boss_adds=3).get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_blade_flurry_hurts_single_target_dps(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        a, b = self.compare_dps({}, {'num_boss_adds': 0})
-        self.assertLess(b, a)
+        base, rank1 = self.compare_dps({}, {'num_boss_adds': 0})
+        self.assertLess(rank1, base)
+
 
     def test_blade_dancer_improves_blade_flurry_penalty(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000'})
-        self.assertLess(a, b)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000'})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='000200000000000000').get_dps()
+        rank3 = self.factory.build(traits='000300000000000000').get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_blade_dancer_multi_target_dps(self):
         cycle = _settings.OutlawCycle(blade_flurry=True)
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000100000000000000', 'num_boss_adds': 3})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='000200000000000000', num_boss_adds=3).get_dps()
+        rank3 = self.factory.build(traits='000300000000000000', num_boss_adds=3).get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_fatebringer_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000010000000000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000010000000000000'})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='000020000000000000').get_dps()
+        rank3 = self.factory.build(traits='000030000000000000').get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_gunslinger_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000001000000000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000001000000000000'})
+        self.assertGreater(rank1, base)
+
 
     def test_hidden_blade_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000100000000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000100000000000'})
+        self.assertGreater(rank1, base)
+
 
     def test_fortune_strikes_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000010000000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000010000000000'})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='000000020000000000').get_dps()
+        rank3 = self.factory.build(traits='000000030000000000').get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_ghostly_shell_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000001000000000'})
-        self.assertEqual(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000001000000000'})
+        self.assertEqual(base, rank1)
+
 
     def test_deception_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000100000000'})
-        self.assertEqual(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000100000000'})
+        self.assertEqual(base, rank1)
+
 
     def test_black_powder_dps(self):
         cycle = _settings.OutlawCycle(between_the_eyes_policy='shark')
-        a, b = self.compare_dps({'traits': '000000000000000000', 'cycle': cycle}, {'traits': '000000000010000000', 'cycle': cycle})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000', 'cycle': cycle}, {'traits': '000000000010000000', 'cycle': cycle})
+        self.assertGreater(rank1, base)
+
 
     def test_greed_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000001000000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000001000000'})
+        self.assertGreater(rank1, base)
+
 
     def test_blurred_time_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000100000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000100000'})
+        self.assertGreater(rank1, base)
+
 
     def test_fortunes_boon_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000010000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000010000'})
+        self.assertGreater(rank1, base)
+        rank2 = self.factory.build(traits='000000000000020000').get_dps()
+        rank3 = self.factory.build(traits='000000000000030000').get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
+
 
     def test_fortunes_strike_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000001000'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000001000'})
+        self.assertGreater(rank1, base)
 
-        a, b2 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000002000'})
-        self.assertGreater(b2, b)
+        rank2 = self.factory.build(traits='000000000000002000').get_dps()
+        rank3 = self.factory.build(traits='000000000000003000').get_dps()
+        self.assertGreater(rank2, rank1)
+        self.assertGreater(rank3, rank2)
 
-        a, b3 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000003000'})
-        self.assertGreater(b3, b2)
 
     def test_blademaster_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000100'})
-        self.assertEqual(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000100'})
+        self.assertEqual(base, rank1)
+
 
     def test_blunderbuss_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000010'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000010'})
+        self.assertGreater(rank1, base)
+
 
     def test_cursed_steel_dps(self):
-        a, b = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000001'})
-        self.assertGreater(b, a)
+        base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '000000000000000001'})
+        self.assertGreater(rank1, base)
+
 
 class TestAssassinationRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
     def setUp(self):

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -153,6 +153,25 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
         self.assertGreater(b["main_gauche"], a["main_gauche"])
 
 
+    def test_energy_regen(self):
+        self.calculator.set_constants()
+        # This is 12.4 base because the calculator currently averages Heroism out over the course of the fight.
+        # Should fix at some point.
+        self.assertAlmostEqual(self.calculator.get_energy_regen({'haste': 0}), 12.4)
+        self.assertAlmostEqual(self.calculator.get_energy_regen({'haste': 5000}), 14.3076923)
+        self.assertAlmostEqual(self.calculator.get_energy_regen({'haste': 5000}, buried=True), 17.8846153846)
+        self.assertAlmostEqual(self.calculator.get_energy_regen({'haste': 5000}, ar=True), 28.615384615384613)
+        self.assertAlmostEqual(self.calculator.get_energy_regen({'haste': 5000}, buried=True, ar=True), 35.76923076923077)
+        self.assertAlmostEqual(self.calculator.get_energy_regen({'haste': 5000}, alacrity_stacks=10), 15.50769230769231)
+        cycle = _settings.OutlawCycle(blade_flurry=True)
+        self.assertEqual(self.factory.build(cycle=cycle).set_constants().get_energy_regen({'haste': 0}), 12.4 * 0.8)
+
+
+    def test_energy_regen_blade_dancer(self):
+        cycle = _settings.OutlawCycle(blade_flurry=True)
+        self.assertEqual(self.factory.build(cycle=cycle,traits='000200000000000000').set_constants().get_energy_regen({'haste': 0}), 12.4 * (0.8 + 0.03333 * 2))
+
+
     def test_cursed_edges_dps(self):
         base, rank1 = self.compare_dps({'traits': '000000000000000000'}, {'traits': '010000000000000000'})
         self.assertGreater(rank1, base)


### PR DESCRIPTION
Refactor the calculator test to allow for bootstrapping calculators more easily for comparing results between calculators. Add tests for Outlaw artifact traits to verify that they improve output as expected. Currently failing black_powder, blade_dancer_multi_target, blurred_time, and hidden_blade.