### PR TITLE
Fix talents ranking; reset talents to baseline before performing rank…

### DIFF
--- a/shadowcraft/objects/talents.py
+++ b/shadowcraft/objects/talents.py
@@ -56,10 +56,24 @@ class Talents(object):
             if int(i) not in range(4):
                 raise InvalidTalentException(_('Values in the talent string must be 0, 1, 2, 3, or sometimes 4'))
             if int(i) == 0 or i == '.':
-                pass
+                setattr(self, self.class_talents[j][int(i) - 1], False)
             else:
                 setattr(self, self.class_talents[j][int(i) - 1], True)
             j += 1
+
+    def get_talent_string(self):
+        talent_str = ""
+        for row in self.class_talents:
+            got_talent = False
+            for index, talent in enumerate(row):
+                if getattr(self, talent):
+                    got_talent = True
+                    talent_str += str(index + 1)
+                    break
+            if not got_talent:
+                talent_str += "0"
+        return talent_str
+
 
     def reset_talents(self):
         for talent in self.allowed_talents:
@@ -73,13 +87,16 @@ class Talents(object):
             if name in self.class_talents[i]:
                 return i
 
-    def set_talent(self, name):
+    def set_talent(self, name, value=True):
         # Clears talents in the tier and sets the new one
         if name not in self.allowed_talents:
             raise InvalidTalentException("Invalid talent")
         for talent in self.class_talents[self.get_tier_for_talent(name)]:
             setattr(self, talent, False)
-        setattr(self, name, True)
+        setattr(self, name, value)
+
+    def get_talent(self, name):
+        return getattr(self, name)
 
     def get_active_talents(self):
         active_talents = []

--- a/shadowcraft/objects/talents.py
+++ b/shadowcraft/objects/talents.py
@@ -52,11 +52,12 @@ class Talents(object):
         if len(talent_string) > self.max_rows:
             raise InvalidTalentException(_('Talent strings must be 7 or less characters long'))
         j = 0
+        self.reset_talents()
         for i in talent_string:
             if int(i) not in range(4):
                 raise InvalidTalentException(_('Values in the talent string must be 0, 1, 2, 3, or sometimes 4'))
             if int(i) == 0 or i == '.':
-                setattr(self, self.class_talents[j][int(i) - 1], False)
+                pass
             else:
                 setattr(self, self.class_talents[j][int(i) - 1], True)
             j += 1

--- a/tests/calcs_tests/rogue_tests/__init__.py
+++ b/tests/calcs_tests/rogue_tests/__init__.py
@@ -139,6 +139,11 @@ class RogueDamageCalculatorTestBase:
     def test_set_constants_for_level(self):
         self.assertRaises(exceptions.InvalidLevelException, self.calculator.__setattr__, 'level', 111)
 
+
+    def test_get_talents_ranking_does_not_change_talents(self):
+        active_talents = self.calculator.talents.get_active_talents()
+        self.assertEqual(self.calculator.talents.get_active_talents(), active_talents)
+
 ## Single target
 
 class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):
@@ -338,7 +343,14 @@ class TestOutlawRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.Te
         self.assertGreater(mfd, snd, 'SnD %s > Marked for Death %s' % (snd, mfd))
         self.assertGreater(mfd, dfa, 'Death From Above %s > mfd %s' % (dfa, mfd))
 
+    def test_get_talents_ranking_does_not_persist_talents_in_same_row(self):
+        self.calculator.talents.initialize_talents("0000000")
+        ranking_without_existing = self.calculator.get_talents_ranking()
 
+        self.calculator.talents.initialize_talents("1000000")
+        ranking_with_existing = self.calculator.get_talents_ranking()
+
+        self.assertEqual(ranking_without_existing[15], ranking_with_existing[15])
 
 
 class TestAssassinationRogueDamageCalculator(RogueDamageCalculatorTestBase, unittest.TestCase):


### PR DESCRIPTION
As found by wavefunctionp, talents were not being properly reset per row, which could allow for things like a talent comparison to be run with both Ghostly Strike and Swordmaster enabled (for example).

This now resets each row prior to running calculations on its talents, and establishes a baseline per row, rather than overall. Includes tests.