### PR TITLE
Fix for Chaos Talisman and Eye of Command stacking

### DIFF
--- a/shadowcraft/calcs/rogue/Aldriana/__init__.py
+++ b/shadowcraft/calcs/rogue/Aldriana/__init__.py
@@ -663,8 +663,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             for proc in active_procs_no_icd:
                 self.set_uptime(proc, attacks_per_second, crit_rates)
                 for e in proc.value:
-                    if e in self.spec_convergence_stats:
-                        convergence_stats = True
+                    convergence_stats = True
                     if e == 'crit':
                         recalculate_crit = True
                     current_stats[ e ] += proc.uptime * proc.value[e] * self.stat_multipliers[e]

--- a/shadowcraft/objects/proc_data.py
+++ b/shadowcraft/objects/proc_data.py
@@ -246,7 +246,7 @@ allowed_procs = {
         'item_level': 805,
         'source': 'trinket',
         'type': 'icd',
-        'icd': 1,
+        'icd': 0, # stacks with every autohit
         'proc_rate': 1,
         'trigger': 'auto_attacks',
    },
@@ -333,7 +333,7 @@ allowed_procs = {
         'item_level': 860,
         'source': 'trinket',
         'type': 'icd',
-        'icd': 1,
+        'icd': 0, # stacks with every autohit
         'proc_rate': 1,
         'trigger': 'auto_attacks',
    },


### PR DESCRIPTION
Whoops, Chaos Talisman and Eye of Command were not stacking correctly with each autohit.