### PR TITLE
Minor fix for racial base stats

### DIFF
--- a/shadowcraft/calcs/__init__.py
+++ b/shadowcraft/calcs/__init__.py
@@ -1,6 +1,8 @@
 import gettext
 import __builtin__
 import math
+import os
+import subprocess
 
 __builtin__._ = gettext.gettext
 
@@ -28,7 +30,7 @@ class DamageCalculator(object):
 
     def __init__(self, stats, talents, traits, buffs, race, spec, settings=None, level=110, target_level=None, char_class='rogue'):
         self.WOW_BUILD_TARGET = '7.1.5' # should reflect the game patch being targetted
-        self.SHADOWCRAFT_BUILD = '0.02' # <1 for beta builds, 1.00 is GM, >1 for any bug fixes, reset for each warcraft patch
+        self.SHADOWCRAFT_BUILD = self.get_version_string()
         self.tools = class_data.Util()
         self.stats = stats
         self.talents = talents
@@ -88,6 +90,14 @@ class DamageCalculator(object):
         # unless it's basic stuff like combat ratings or base stats that we can
         # datamine for all classes/specs at once.
         self.game_class = self.talents.game_class
+
+    def get_version_string(self):
+        thisdir = os.path.dirname(os.path.abspath(__file__))
+        build = subprocess.check_output('git rev-list --count HEAD', cwd=thisdir).strip()
+        commit = subprocess.check_output('git rev-parse --short HEAD', cwd=thisdir).strip()
+        if build and commit:
+            return '{0} ({1})'.format(build, commit)
+        return 'UNKNOWN'
 
     def recalculate_hit_constants(self):
         self.base_dw_miss_rate = self.base_one_hand_miss_rate + self.dw_miss_penalty

--- a/shadowcraft/objects/race.py
+++ b/shadowcraft/objects/race.py
@@ -139,6 +139,7 @@ class Race(object):
             self.activated_racial_data["blood_fury_spell"]["value"] = self.blood_fury_bonuses[self.level]["sp"]
             # this merges racial stats with class stats (ie, racial_stat_offset and rogue_base_stats)
             self.stats = map(sum, zip(self.stats, Race.racial_stat_offset[self.race_name]))
+            self.set_racials()
         except KeyError as e:
             raise InvalidRaceException(_('Unsupported class/level combination {character_class}/{level}').format(character_class=self.character_class, level=self.level))
 
@@ -148,17 +149,6 @@ class Race(object):
             return False
         else:
             object.__getattribute__(self, name)
-
-    def get_stats_from_race(self, level, secondaries=False):
-        str = Race.rogue_base_stats[level][0] + Race.racial_stat_offset[self.race_name][0]
-        agi = Race.rogue_base_stats[level][1] + Race.racial_stat_offset[self.race_name][1]
-        sta = Race.rogue_base_stats[level][2] + Race.racial_stat_offset[self.race_name][2]
-        int = Race.rogue_base_stats[level][3] + Race.racial_stat_offset[self.race_name][3]
-        spi = Race.rogue_base_stats[level][4] + Race.racial_stat_offset[self.race_name][4]
-        if secondaries:
-            return {'agi':agi, 'str':str, 'sta':sta, 'int':int, 'spi':spi,
-                    'readiness':0, 'multistrike':0, 'versatility':0, 'haste':0, 'crit':0, 'mastery':0}
-        return {'agi':agi, 'str':str, 'sta':sta, 'int':int, 'spi':spi}
 
     def get_racial_crit(self, is_day=False):
         crit_bonus = 0

--- a/shadowcraft/objects/stats.py
+++ b/shadowcraft/objects/stats.py
@@ -5,11 +5,10 @@ from shadowcraft.objects import race
 from shadowcraft.core import exceptions
 
 class Stats(object):
-    # For the moment, lets define this as raw stats from gear + race; AP is
-    # only AP bonuses from gear and level.  Do not include multipliers like
-    # Vitality and Sinister Calling; this is just raw stats.  See calcs page
-    # rows 1-9 from my WotLK spreadsheets to see how these are typically
-    # defined, though the numbers will need to updated for level 85.
+    # For the moment, lets define this as raw stats from gear
+    # AP is only AP bonuses from gear (as of Legion usually 0)
+    # Other base stat bonuses are added in get_character_base_stats
+    # Multipliers are added in get_character_stat_multipliers
 
     crit_rating_conversion_values        = {60:13.0, 70:14.0,  80:15.0,  85:17.0,  90:23.0,  100:110.0,  110:400.0}
     haste_rating_conversion_values       = {60:9.00, 70:10.0,  80:12.0,  85:14.0,  90:20.0,  100:100.0,  110:375.0}


### PR DESCRIPTION
This fix does not affect the current live version of ShadowCraft because the backend is initializing the race with the level.
My test script, however, is not. This means that, when `race.level` was set from the DamageCalculator, the racial_X members were not updated because `set_racials()` was not called again. The result was a calculation with base stats for level 85.